### PR TITLE
Create Recaptcha_ServiceController.php

### DIFF
--- a/controllers/Recaptcha_ServiceController.php
+++ b/controllers/Recaptcha_ServiceController.php
@@ -1,0 +1,28 @@
+<?php
+namespace Craft;
+
+/**
+ * Recaptcha controller
+ */
+class Recaptcha_ServiceController extends BaseController
+{
+    protected $allowAnonymous = true;
+	/**
+	 * Handle the save user form request.
+	 */
+	public function actionSaveUser()
+	{
+        $this->requirePostRequest();
+		$captcha = craft()->request->getPost('g-recaptcha-response');
+		$verified = craft()->recaptcha_verify->verify($captcha);
+		
+		if ($verified)
+		{
+			$this->forward('users/saveUser');
+		} else {
+            craft()->urlManager->setRouteVariables(array(
+               "Failed Recaptcha validation",
+            ));
+		}
+	}
+}


### PR DESCRIPTION
This controller handles the most common case for wanting to use Recaptcha, the sign-up form.  Just use it like this:

```
        <form method="post" accept-charset="UTF-8">
            {{ getCsrfInput() }}
            <input type="hidden" name="action" value="recaptcha/service/saveUser">
```

...and if the user passes the Recaptcha test, they are saved as a new user, the data forwarded on to 'users/saveUser'
