### PR TITLE
If validation fails, return an 'errors' array via craft()->urlManager…

### DIFF
--- a/recaptcha/controllers/Recaptcha_ServiceController.php
+++ b/recaptcha/controllers/Recaptcha_ServiceController.php
@@ -18,7 +18,7 @@ class Recaptcha_ServiceController extends BaseController
 		
 		if ($verified)
 		{
-			$this->forward('users/saveUser');
+			$this->forward('users/saveUser', false);
 		}
 		else
 		{

--- a/recaptcha/controllers/Recaptcha_ServiceController.php
+++ b/recaptcha/controllers/Recaptcha_ServiceController.php
@@ -19,9 +19,11 @@ class Recaptcha_ServiceController extends BaseController
 		if ($verified)
 		{
 			$this->forward('users/saveUser');
-		} else {
+		}
+		else
+		{
             craft()->urlManager->setRouteVariables(array(
-               'errors' => array("Failed Recaptcha validation",
+               'errors' => array('Failed Recaptcha validation',
                )
             ));
 		}

--- a/recaptcha/controllers/Recaptcha_ServiceController.php
+++ b/recaptcha/controllers/Recaptcha_ServiceController.php
@@ -21,7 +21,8 @@ class Recaptcha_ServiceController extends BaseController
 			$this->forward('users/saveUser');
 		} else {
             craft()->urlManager->setRouteVariables(array(
-               "Failed Recaptcha validation",
+               'errors' => array("Failed Recaptcha validation",
+               )
             ));
 		}
 	}

--- a/recaptcha/controllers/Recaptcha_ServiceController.php
+++ b/recaptcha/controllers/Recaptcha_ServiceController.php
@@ -7,25 +7,25 @@ namespace Craft;
 class Recaptcha_ServiceController extends BaseController
 {
     protected $allowAnonymous = true;
-	/**
-	 * Handle the save user form request.
-	 */
-	public function actionSaveUser()
-	{
+    /**
+     * Handle the save user form request.
+     */
+    public function actionSaveUser()
+    {
         $this->requirePostRequest();
-		$captcha = craft()->request->getPost('g-recaptcha-response');
-		$verified = craft()->recaptcha_verify->verify($captcha);
-		
-		if ($verified)
-		{
-			$this->forward('users/saveUser', false);
-		}
-		else
-		{
+        $captcha = craft()->request->getPost('g-recaptcha-response');
+        $verified = craft()->recaptcha_verify->verify($captcha);
+        
+        if ($verified)
+        {
+            $this->forward('users/saveUser', false);
+        }
+        else
+        {
             craft()->urlManager->setRouteVariables(array(
                'errors' => array('Failed Recaptcha validation',
                )
             ));
-		}
-	}
+        }
+    }
 }


### PR DESCRIPTION
Made it so that it returns the standard `errors` array if validation fails in the `saveUser` controller
